### PR TITLE
add: create automation to publish releases on merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,16 @@
+---
+name: Build new release
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  Build new release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: rymndhng/release-on-push-action@v0.27.0
+        with:
+          bump_version_scheme: patch
+          tag_prefix: ""
+          use_github_release_notes: true


### PR DESCRIPTION
Merging a PR should now build releases automatically. Hopefully this way I won't forget.