### PR TITLE
feat: add Vagrant testing to GH actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,12 +1,12 @@
 ---
-name: Linting
-run-name: Run linting and syntax checks
+name: Lint
+run-name: Lint for ${{ github.event_name }}:${{ github.ref }} (${{ github.sha }})
 'on':
   push:
     branches: main
   pull_request:
   schedule:
-    - cron: "0 7 * * 0"
+    - cron: "0 7 * * 1"
 
 jobs:
   Lint:
@@ -16,17 +16,43 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
 
-      - name: Set up dependencies from repositories
-        run: sudo apt update && sudo apt install -y python3-pip make
+      ################
+      # Caches
+      ################
+      - name: Cache Ansible Galaxy roles
+        uses: actions/cache@v3
+        with:
+          path: roles/
+          key: ansible-galaxy-roles-${{ hashFiles('roles/requirements.yml') }}
 
-      - name: Set up dependencies from pip
-        run: sudo pip install ansible ansible-lint yamllint
+      - name: Cache Ansible Galaxy collections
+        uses: actions/cache@v3
+        with:
+          path: collections/
+          key: ansible-galaxy-collections-${{ hashFiles('collections/requirements.yml') }}
 
-      - name: Configure Ansible galaxy dependencies
+      ################
+      # Bootstrapping
+      ################
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Set up APT dependencies
+        run: sudo apt update && sudo apt install -y make
+
+      - name: Set up PIP dependencies
+        run: sudo pip install ansible==6.5 ansible-lint yamllint
+
+      - name: Set up Ansible Galaxy dependencies
         run: make dependencies
 
-      - name: Run ansible-lint
+      ################
+      # Linting
+      ################
+      - name: Lint (ansible-lint)
         run: ansible-lint -vv .
 
-      - name: Lint all yaml files
-        run: yamllint .
+      - name: Lint (yamllint)
+        run: yamllint -s .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,77 @@
+---
+name: Test
+run-name: Test for ${{ github.event_name }}:${{ github.ref }} (${{ github.sha }})
+'on':
+  push:
+  schedule:
+    - cron: "0 0 * * 1"
+
+jobs:
+  Test:
+    runs-on: macos-10.15
+    strategy:
+      fail-fast: false
+      matrix:
+        host: ["ubuntu20-laptop", "ubuntu20-desktop", "ubuntu22-desktop"]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      ################
+      # Caches
+      ################
+      - name: Cache Vagrant boxes
+        uses: actions/cache@v3
+        with:
+          path: ~/.vagrant.d/boxes
+          key: vagrant-boxes
+
+      - name: Cache Ansible Galaxy roles
+        uses: actions/cache@v3
+        with:
+          path: roles/
+          key: ansible-galaxy-roles-${{ hashFiles('roles/requirements.yml') }}
+
+      - name: Cache Ansible Galaxy collections
+        uses: actions/cache@v3
+        with:
+          path: collections/
+          key: ansible-galaxy-collections-${{ hashFiles('collections/requirements.yml') }}
+
+      ################
+      # Bootstrapping
+      ################
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Set up Ansible
+        run: pip install ansible==6.5
+
+      - name: Set up MacOS requirements
+        run: pip install passlib
+
+      - name: Set up Ansible homedir and show tools versions
+        run: ansible --version && vagrant --version
+
+      - name: Set up Ansible Vault
+        run: echo "$VAULT_TOKEN" > ~/.ansible/default.vault && chmod 600 ~/.ansible/default.vault
+        env:
+          VAULT_TOKEN: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
+
+      - name: Set up Ansible Galaxy dependencies
+        run: make dependencies
+
+      - name: Provision Vagrant box
+        run: make test ANSIBLE_ARGS="-l localhost,${{ matrix.host }}" VAGRANT_BOX="${{ matrix.host }}"
+
+      ################
+      # Artifacts
+      ################
+      - name: Upload logs
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: ansible.log
+          path: config/tmp/ansible.log

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ collections/vendors/*
 *.pyc
 *.retry
 
-# Vagrant state
+# Vagrant state and artifacts
 vagrant/.vagrant
 vagrant/.vagrant/*
+vagrant/ubuntu.vm

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -8,3 +8,4 @@ ignore: |
   vault_*.yml
   collections/vendors
   roles/vendors
+  .github/

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,15 @@
+ANSIBLE_ARGS=
+VAGRANT_BOX="ubuntu20-desktop"
 
 dependencies:
-	ansible-galaxy role install -f -r roles/requirements.yml -p roles/vendors
-	ansible-galaxy collection install -f -r collections/requirements.yml -p collections/vendors
+	ansible-galaxy role install -r roles/requirements.yml -p roles/vendors
+	ansible-galaxy collection install -r collections/requirements.yml -p collections/vendors
 
 clean:
 	rm -rf roles/vendors/* collections/vendors/*
 
 test:
-	cd vagrant && vagrant up --provision && cd .. || cd ..
+	(cd vagrant; ANSIBLE_ARGS="$(ANSIBLE_ARGS)" vagrant up $(VAGRANT_BOX) --provision)
 
 destroy:
-	cd vagrant && vagrant destroy -f && cd .. || cd ..
+	(cd vagrant; vagrant destroy -f)

--- a/config/ansible.cfg
+++ b/config/ansible.cfg
@@ -75,3 +75,4 @@ transport         = smart
 
 [inventory]
 any_unparsed_is_failed  = True
+

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -2,8 +2,21 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box         = "hluaces/ubuntu-gnome"
-  config.vm.box_version = "20.04"
+  config.vm.define "ubuntu20-desktop", primary: true do |ubuntu|
+    ubuntu.vm.box         = "hluaces/ubuntu-gnome"
+    ubuntu.vm.box_version = "20.04.04"
+  end
+
+  config.vm.define "ubuntu20-laptop" do |ubuntu|
+    ubuntu.vm.box         = "hluaces/ubuntu-gnome"
+    ubuntu.vm.box_version = "20.04.04"
+  end
+
+  config.vm.define "ubuntu22-desktop" do |ubuntu|
+    ubuntu.vm.box         = "hluaces/ubuntu-gnome"
+    ubuntu.vm.box_version = "22.04.01"
+  end
+
   config.ssh.insert_key = false
   vagrant_root          = File.dirname(__FILE__)
 
@@ -18,5 +31,7 @@ Vagrant.configure("2") do |config|
     ansible.config_file    = "../ansible.cfg"
     ansible.inventory_path = "../inventory/default.ini"
     ansible.limit          = "ubuntu20-laptop,localhost"
+    ansible.verbose        = "vv"
+    ansible.raw_arguments  = Shellwords.shellsplit(ENV['ANSIBLE_ARGS']) if ENV['ANSIBLE_ARGS']
   end
 end


### PR DESCRIPTION
- feat: add Vagrant provisioning tests to GH actions (also with schedule)
- feat: `Vagrantfile` now defines one box per machine in the inventory
- feat: `make test` now allows to pass parameters to Ansible
- feat: `make test` now allows to specify the box being provisioned
- chore: optimize the `Lint` workflow so that it reuses caches for Ansible Galaxy
- fix: minor tweaks to the `Makefile` to avoid `cd`ing back and forth
- feat: allow `make test` to pass arbitrary parameters to the Ansible provisioner
- fix: `yamllint` will now run in strict mode
- fix: `yamllint` will no longer validate GH actions
- fix: minor tweaks to the `.gitignore`

Once this is merged I'll probably follow up to tweak the Vagrant workflow to make it be triggered on `workflow_run` events after the Linting is done.