### PR TITLE
fix: do not use `become` by default

### DIFF
--- a/config/ansible.cfg
+++ b/config/ansible.cfg
@@ -75,6 +75,3 @@ transport         = smart
 
 [inventory]
 any_unparsed_is_failed  = True
-
-[privilege_escalation]
-become = True

--- a/roles/local/joplin/tasks/main.yml
+++ b/roles/local/joplin/tasks/main.yml
@@ -2,6 +2,4 @@
 
 - name: 'Download and execute Joplin install script'
   ansible.builtin.shell: "wget -O - {{ joplin_install_script }} | bash"
-  environment:
-    TERM: 'xterm'
   tags: ['skip_ansible_lint']


### PR DESCRIPTION
After the `ansible.cfg` refactor the `become = true` setting might have introduced errors in the whole playbook install, including a recent joplin bug that had to do with the missing XTERM.

This reverts that setting back.