### PR TITLE
fix: make the dropbox role retry downloads

### DIFF
--- a/roles/local/dropbox/tasks/install.yml
+++ b/roles/local/dropbox/tasks/install.yml
@@ -15,8 +15,20 @@
     keyserver: 'pgp.mit.edu'
     id: '1C61A2656FB57B7E4DE0F4C1FC918B335044912E'
 
+# Dropbox is prone to serve 404s, so this task is here to minimise blips
+- name: 'Download the Dropbox .deb package'
+  ansible.builtin.get_url:
+    url: "{{ dropbox_deb_package_url }}"
+    dest: "{{ dropbox_tmp_deb_file }}"
+    force: true
+    mode: "0600"
+  register: _get_dropbox
+  until: not _get_dropbox.failed
+  retries: 5
+  delay: 20
+
 - name: 'Install the Dropbox .deb package'
   ansible.builtin.apt:
-    deb: "{{ dropbox_deb_package_url }}"
+    deb: "{{ dropbox_tmp_deb_file }}"
     state: 'present'
   when: ansible_facts['distribution_file_variety'] == 'Debian'

--- a/roles/local/dropbox/vars/main.yml
+++ b/roles/local/dropbox/vars/main.yml
@@ -1,3 +1,5 @@
 ---
 
 dropbox_deb_package_url: 'https://linux.dropbox.com/packages/ubuntu/dropbox_2020.03.04_amd64.deb'
+
+dropbox_tmp_deb_file: "/tmp/dropbox.deb"


### PR DESCRIPTION
I've been dealing with a lot of 404s lately when trying to download the `.deb` package from Dropbox. Downloading it with retries should alleviate the problem a little bit and also offer less cryptic error messages.