### PR TITLE
fix: upgrade APT requirements

### DIFF
--- a/roles/local/extra_packages/tasks/apt_packages.yml
+++ b/roles/local/extra_packages/tasks/apt_packages.yml
@@ -3,6 +3,7 @@
 - name: 'Install and upgrade APT utilities for Ansible'
   ansible.builtin.apt:
     name: ['ca-certificates', 'apt-transport-https']
+    state: 'latest'
     update_cache: true
 
 - name: 'Manage extra APT-keys from keyservers'


### PR DESCRIPTION
Without an upgraded set of `ca-certificates` a lot of APT operations (keys, repos, packages) will fail and Ansible will display weird errors that are red herrings (such as: "_That repo is invalid_") instead of actually stating the problem with the certificates.