### PR TITLE
fix: make joplin compatible with pipelining

### DIFF
--- a/roles/local/joplin/tasks/main.yml
+++ b/roles/local/joplin/tasks/main.yml
@@ -2,4 +2,6 @@
 
 - name: 'Download and execute Joplin install script'
   ansible.builtin.shell: "wget -O - {{ joplin_install_script }} | bash"
+  environment:
+    TERM: 'xterm-256color'
   tags: ['skip_ansible_lint']


### PR DESCRIPTION
The joplin install script relies on `tput setaf` commands to display colors on screen. That command needs to check the current active terminal type to know how to display colors.

When using Ansible with pipelining enabled there's no such thing as a terminal, and as such, this makes the script fail with:

```
tput: unknown terminal "unknown"
```

This change tricks `tput` into believing there's an active terminal and allows the script to continue.

This problem wasn't detected before because prior to my `ansible.cfg` refactor (46bf08dac843b30198e92387afce27e65a71f19c) pipelining was not enabled due to the fact that it was set in the wrong section.

At some point I did this exact same change but reverted it aftewards (76a55a5781cef6cfb1c9d78219cae7bdc9132375) because I believed the problem was in a wrong `become` setting. Hopefully this solves the issue once and for all.