### PR TITLE
fix: don't cache local resources in actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,13 +22,13 @@ jobs:
       - name: Cache Ansible Galaxy roles
         uses: actions/cache@v3
         with:
-          path: roles/
+          path: roles/vendors
           key: ansible-galaxy-roles-${{ hashFiles('roles/requirements.yml') }}
 
       - name: Cache Ansible Galaxy collections
         uses: actions/cache@v3
         with:
-          path: collections/
+          path: collections/vendors
           key: ansible-galaxy-collections-${{ hashFiles('collections/requirements.yml') }}
 
       ################

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,13 +29,13 @@ jobs:
       - name: Cache Ansible Galaxy roles
         uses: actions/cache@v3
         with:
-          path: roles/
+          path: roles/vendors/
           key: ansible-galaxy-roles-${{ hashFiles('roles/requirements.yml') }}
 
       - name: Cache Ansible Galaxy collections
         uses: actions/cache@v3
         with:
-          path: collections/
+          path: collections/vendors/
           key: ansible-galaxy-collections-${{ hashFiles('collections/requirements.yml') }}
 
       ################


### PR DESCRIPTION
This was probably causing a lot of random errors as of late as bugged resources were being fetched from cache.