### PR TITLE
fix: disable joplin role from GH test workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,7 +64,7 @@ jobs:
         run: make dependencies
 
       - name: Provision Vagrant box
-        run: make test ANSIBLE_ARGS="-l localhost,${{ matrix.host }}" VAGRANT_BOX="${{ matrix.host }}"
+        run: make test ANSIBLE_ARGS="-l localhost,${{ matrix.host }} --skip-tags=role-joplin" VAGRANT_BOX="${{ matrix.host }}"
 
       ################
       # Artifacts


### PR DESCRIPTION
# Disable joplin in GH test runs

<!-- This PR fixes #NUMBER_OF_THE_ISSUE, and fixes #NUMBER_OF_THE_ISSUE -->

## **Description**

This is unfortunate, but right now I don't see a better and quick alternative.

The problem is that the Joplin installer script leverages GitHub's API to fetch the artifacts from a release and GH shared runners tend to be Rate-limited. As such, test runs always fail when installing Joplin.
