### PR TITLE
[norelease] avoid artifact name collision

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,5 +73,5 @@ jobs:
         uses: actions/upload-artifact@v3
         if: always()
         with:
-          name: ansible.log
+          name: ansible-${{ matrix.host }}.log
           path: config/tmp/ansible.log


### PR DESCRIPTION
# Avoid artifact name collision

## **Description**


As all matrix publish the same logfile we end up by retaining just a single one. This PR should address that problem.