### PR TITLE
fix: bump & pin minors for ansible & ansible-lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,7 +43,7 @@ jobs:
         run: sudo apt update && sudo apt install -y make
 
       - name: Set up PIP dependencies
-        run: sudo pip install ansible==6.5 ansible-lint yamllint
+        run: pip install ansible==6.7 ansible-lint==6.12 yamllint==1.29
 
       - name: Set up Ansible Galaxy dependencies
         run: make dependencies


### PR DESCRIPTION
# bump & pin minors for ansible & ansible-lint

<!-- This PR fixes #NUMBER_OF_THE_ISSUE, and fixes #NUMBER_OF_THE_ISSUE -->

## **Description**

GH actions were failing with:

```
Ansible CLI (2.14.2) and python module (2.13.7) versions do not match. 
This indicates a broken execution environment.
```

Hopefully, a stricter pin fixes these problems.

### **Additional context**

See:

- https://github.com/hluaces-ansible/ansible-ubuntu/actions/runs/4160948469