### PR TITLE
fix: use ubuntu keyserver for dropbox install

### DIFF
--- a/collections/local/ansible_collections/hluaces/gnome/roles/dropbox/tasks/install.yml
+++ b/collections/local/ansible_collections/hluaces/gnome/roles/dropbox/tasks/install.yml
@@ -12,7 +12,7 @@
 
 - name: 'Add Dropbox GPG key'
   ansible.builtin.apt_key:
-    keyserver: 'pgp.mit.edu'
+    keyserver: 'keyserver.ubuntu.com'
     id: '1C61A2656FB57B7E4DE0F4C1FC918B335044912E'
 
 # Dropbox is prone to serve 404s, so this task is here to minimise blips


### PR DESCRIPTION
# Use ubuntu keyserver for dropbox install

## **Description**


`pgp.mit.edu` doesn't work half the time. Unsure why it was hardcoded there. Let's use the keyserver for ubuntu to work around that.

### **Additional context**

Sample error:

```
[01:00:40]     ↳ install : Add Dropbox GPG key ...miércoles 08 marzo 2023  01:00:40 +0100 (0:00:09.493)       0:15:31.215 ******* 
miércoles 08 marzo 2023  01:00:40 +0100 (0:00:09.493)       0:15:31.214 ******* 
 | ubuntu20-laptop | FAILED | 3.42s
{
  - stdout: Executing: /tmp/apt-key-gpghome.KCldeBh2Nv/gpg.1.sh --no-tty --keyserver pgp.mit.edu --recv 1C61A2656FB57B7E4DE0F4C1FC918B335044912E
  - rc: 2
  - stderr: Warning: apt-key output should not be parsed (stdout is not a terminal)
            gpg: keyserver receive failed: No keyserver available
  - msg: Error fetching key 1C61A2656FB57B7E4DE0F4C1FC918B335044912E from keyserver: pgp.mit.edu
  - cmd: /usr/bin/apt-key adv --no-tty --keyserver pgp.mit.edu --recv 1C61A2656FB57B7E4DE0F4C1FC918B335044912E
  - forced_environment: {
    - LANG: C.UTF-8
    - LC_ALL: C.UTF-8
    - LC_MESSAGES: C.UTF-8
  }
  - stderr_lines: [ 
    - Warning: apt-key output should not be parsed (stdout is not a terminal)
    - gpg: keyserver receive failed: No keyserver available
   ]
  - changed: False
}

```.
