### PR TITLE
ci: fix molecule URL error

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,17 +10,17 @@ lint: |
   yamllint -s .
   ansible-lint .
 platforms:
-  - name: 'ubuntu22-desktop'
-    box: 'hluaces/ubuntu-gnome'
-    box_version: '22.04.1'
+  - name: ubuntu22-desktop
+    box: hluaces/ubuntu-gnome
+    box_version: 22.04.1
     groups: ['ubuntu_group']
-  - name: 'ubuntu20-laptop'
-    box: 'hluaces/ubuntu-gnome'
-    box_version: '20.04.04'
+  - name: ubuntu20-laptop
+    box: hluaces/ubuntu-gnome
+    box_version: 20.04.04
     groups: ['ubuntu_group']
-  - name: 'ubuntu20-desktop'
-    box: 'hluaces/ubuntu-gnome'
-    box_version: '20.04.04'
+  - name: ubuntu20-desktop
+    box: hluaces/ubuntu-gnome
+    box_version: 20.04.04
     groups: ['ubuntu_group']
 provisioner:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,10 +5,6 @@ dependency:
   command: 'make dependencies'
 driver:
   name: vagrant
-lint: |
-  set -e
-  yamllint -s .
-  ansible-lint .
 platforms:
   - name: ubuntu22-desktop
     box: hluaces/ubuntu-gnome


### PR DESCRIPTION
# Avoid escaped quotes in molecule Vagrantfile 

<!-- This PR fixes #NUMBER_OF_THE_ISSUE, and fixes #NUMBER_OF_THE_ISSUE -->

## **Description**

This attempts to work around the issue and unblock CI.

See:

- https://github.com/hluaces-ansible/ansible-ubuntu/actions/runs/4919110410/jobs/8812101079



```

Molecule default > create
  [21:51:33] Create molecule instance(s) ...Tuesday 09 May 2023  21:51:33 +0000 (0:00:00.078)       0:00:00.078 ***********
  Tuesday 09 May 2023  21:51:33 +0000 (0:00:00.077)       0:00:00.077 ***********
   | localhost | FAILED | 7.19s
  {
    - msg: Failed to validate generated Vagrantfile: b'Vagrant failed to initialize at a very early stage:\n\nThere is a syntax error in the following Vagrantfile. The syntax error\nmessage is reproduced below for convenience:\n\n/Users/runner/.cache/molecule/ansible-ubuntu/default/Vagrantfile:16: syntax error, unexpected &\n    c.vm.box_version = &#34;22.04.1&#34;\n                       ^\n/Users/runner/.cache/molecule/ansible-ubuntu/default/Vagrantfile:77: syntax error, unexpected &\n    c.vm.box_version = &#34;20.04.04&#34;\n                       ^\n/Users/runner/.cache/molecule/ansible-ubuntu/default/Vagrantfile:138: syntax error, unexpected &\n    c.vm.box_version = &#34;20.04.04&#34;\n                       ^\n'
    - changed: False
  }
```