### PR TITLE
chore: revert molecule to v4, bump ansible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-ansible==7.4.0
+ansible==7.5.0
 ansible-lint==6.15.0
 yamllint==1.31.0
 molecule==4.0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 ansible==7.4.0
 ansible-lint==6.15.0
 yamllint==1.31.0
-molecule==5.0.0
-molecule-plugins==23.4.1
-molecule-plugins[vagrant]==23.4.1
-molecule-plugins[docker]==23.4.1
+molecule==4.0.4
+molecule-docker==2
+molecule-vagrant==2
 passlib==1.7.4
 python-vagrant==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 ansible==7.5.0
+ansible-compat==3.0.2
 ansible-lint==6.15.0
 yamllint==1.31.0
 molecule==4.0.4


### PR DESCRIPTION
# Revert molecule to v4, bump ansible

<!-- This PR fixes #NUMBER_OF_THE_ISSUE, and fixes #NUMBER_OF_THE_ISSUE -->

## **Description**

Molecule v5 has issues with plugins.

Since this is blocking so many dependencies from merging I'm reverting it back.

### **Additional context**

- https://github.com/ansible-community/molecule-plugins/issues/138
- https://github.com/hluaces-ansible/ansible-ubuntu/actions/runs/4931063550/jobs/8812707648?pr=67
- f53c42446c10c922c30956d4bb2133b612bffb53
- 503ce3807cd7db7dd871706778c7de0900be88a4


