### PR TITLE
fix: install firefox from apt, not snap

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ run-name: Test for ${{ github.event_name }}:${{ github.ref }} (${{ github.sha }}
 
 jobs:
   Test:
-    runs-on: macos-12
+    runs-on: self-hosted
     strategy:
       fail-fast: false
       matrix:

--- a/inventory/host_vars/ubuntu22-desktop/vars.yml
+++ b/inventory/host_vars/ubuntu22-desktop/vars.yml
@@ -34,6 +34,8 @@ extra_packages_repositories:
     repo: 'deb [arch=amd64,arm64,armhf] https://packages.microsoft.com/repos/code stable main'
   - name: 'hashicorp'
     repo: 'deb [arch=amd64] https://apt.releases.hashicorp.com focal main'
+  - name: 'mozillateam'
+    repo: 'ppa:mozillateam/ppa'
 
 # Extra APT packages to install
 # See "extra_packages" role
@@ -136,6 +138,9 @@ extra_packages_snaps:
     channel: 'latest/beta'
   - name: 'authy'
     channel: 'latest/beta'
+  # We don't want firefox on snap
+  - name: 'firefox'
+    state: 'absent'
 
 # Pip packages to install
 extra_packages_pip:

--- a/inventory/host_vars/ubuntu22-laptop/vars.yml
+++ b/inventory/host_vars/ubuntu22-laptop/vars.yml
@@ -36,6 +36,8 @@ extra_packages_repositories:
     repo: 'deb [arch=amd64] https://apt.releases.hashicorp.com jammy main'
   - name: 'slimbook'
     repo: 'ppa:slimbook/slimbook'
+  - name: 'mozillateam'
+    repo: 'ppa:mozillateam/ppa'
 
 # Extra APT packages to install
 # See "extra_packages" role
@@ -147,6 +149,9 @@ extra_packages_snaps:
   - name: 'postman'
   - name: 'telegram-desktop'
     channel: 'latest/beta'
+  # We don't want firefox on snap
+  - name: 'firefox'
+    state: 'absent'
 
 # Pip packages to install
 extra_packages_pip:

--- a/playbooks/tasks/ubuntu22-desktop/root/firefox.yml
+++ b/playbooks/tasks/ubuntu22-desktop/root/firefox.yml
@@ -1,0 +1,32 @@
+---
+
+- name: 'Add apt-priority to the mozillateam repo'
+  ansible.builtin.copy:
+    dest: '/etc/apt/preferences.d/mozillateam.pref'
+    content: |
+      # To prevent repository packages from triggering the installation of Ubuntus snap
+      # version of firefox, this file prioritizes the packages of mozillateam
+
+      Package: firefox*
+      Pin: release o=LP-PPA-mozillateam
+      Pin-Priority: 1001
+    force: true
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+
+- name: 'Configure unattended-upgrades to use the mozilateam repo'
+  ansible.builtin.copy:
+    dest: '/etc/apt/apt.conf.d/51unattended-upgrades-firefox'
+    content: |
+      Unattended-Upgrade::Allowed-Origins:: "LP-PPA-mozillateam:${distro_codename}";
+    force: true
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+
+- name: 'Install firefox from apt'
+  ansible.builtin.apt:
+    name: 'firefox'
+    state: 'latest'
+    update_cache: true

--- a/playbooks/tasks/ubuntu22-laptop/root/firefox.yml
+++ b/playbooks/tasks/ubuntu22-laptop/root/firefox.yml
@@ -1,0 +1,32 @@
+---
+
+- name: 'Add apt-priority to the mozillateam repo'
+  ansible.builtin.copy:
+    dest: '/etc/apt/preferences.d/mozillateam.pref'
+    content: |
+      # To prevent repository packages from triggering the installation of Ubuntus snap
+      # version of firefox, this file prioritizes the packages of mozillateam
+
+      Package: firefox*
+      Pin: release o=LP-PPA-mozillateam
+      Pin-Priority: 1001
+    force: true
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+
+- name: 'Configure unattended-upgrades to use the mozilateam repo'
+  ansible.builtin.copy:
+    dest: '/etc/apt/apt.conf.d/51unattended-upgrades-firefox'
+    content: |
+      Unattended-Upgrade::Allowed-Origins:: "LP-PPA-mozillateam:${distro_codename}";
+    force: true
+    owner: 'root'
+    group: 'root'
+    mode: '0644'
+
+- name: 'Install firefox from apt'
+  ansible.builtin.apt:
+    name: 'firefox'
+    state: 'latest'
+    update_cache: true


### PR DESCRIPTION
Firefox on snap has a few problems, as the sandbox prevents me from
using the libraries required for my national ID card.
