### PR TITLE
fix(ci): move CI to self-hosted runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,10 @@ jobs:
       ################
       # Artifacts
       ################
+      - name: Clean up molecule resources
+        if: always()
+        run: molecule destroy --all --parallel
+
       - name: Upload ansible logs
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ run-name: Test for ${{ github.event_name }}:${{ github.ref }} (${{ github.sha }}
 
 jobs:
   Test:
-    runs-on: macos-12
+    runs-on: self-hosted
     strategy:
       fail-fast: false
       matrix:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,14 +9,14 @@ platforms:
   - name: ubuntu22-desktop
     box: hluaces/ubuntu-gnome
     box_version: 22.04.1
-    memory: 1024
-    cpus: 1
+    memory: 4096
+    cpus: 4
     groups: ['ubuntu_group']
   - name: ubuntu22-laptop
     box: hluaces/ubuntu-gnome
     box_version: 22.04.01
-    memory: 1024
-    cpus: 1
+    memory: 4096
+    cpus: 4
     groups: ['ubuntu_group']
 provisioner:
   name: ansible


### PR DESCRIPTION
MacOS-12 runners no longer seem to properly work with vagrant + virtualbox.

A lot of esoteric errors are causing all pipelines that rely on those to fail. This has been ongoing for a while now, and I don't believe GitHub is really interested in fixing those.

This PR configures the repo to rely on a self-hosted runner which is assumed to be properly configured for this.
