### PR TITLE
feat(ci): add workflows to provision runners

### DIFF
--- a/.github/actions/runners/delete_offline/action.yml
+++ b/.github/actions/runners/delete_offline/action.yml
@@ -1,0 +1,30 @@
+---
+name: Delete offline runners in a given repo
+description: Deletes offline runners in a given repo.
+
+inputs:
+  repository:
+    description: Path to the repo (owner/repo-name).
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Delete offline self-hosted runners for ${{ inputs.repository }}
+      shell: bash
+      run: |
+        IDS=$(gh api --method GET \
+          -H 'Accept: application/vnd.github+json' \
+          /repos/${{ inputs.repository }}/actions/runners \
+          | jq -r '.runners[] | select(.status == "online").id' \
+        )
+
+        for id in $IDS; do
+          echo "🕐 Deleting offline runner ${id}..."
+          gh api --method DELETE \
+            -H 'Accept: application/vnd.github+json' \
+            /repos/${{ inputs.repository }}/actions/runners/$id
+          echo "✅ Done"
+        done
+
+        echo "Offline runner cleanup finished"

--- a/.github/actions/runners/get_token/action.yml
+++ b/.github/actions/runners/get_token/action.yml
@@ -1,0 +1,29 @@
+---
+name: Gets self-hosted runner token
+description: Gets the token required to add a new self-hosted runner to a given repository.
+
+inputs:
+  repository:
+    description: Path to the repo (owner/repo-name).
+    required: true
+
+outputs:
+  token:
+    description: ID of the created instance.
+    value: ${{ steps.get_token.outputs.token }}
+
+runs:
+  using: composite
+  steps:
+    - name: Fetch self-hosted runner token from the repo
+      id: get_token
+      shell: bash
+      run: |
+        TOKEN=$(gh api --method POST \
+          -H "Accept: application/vnd.github+json" \
+          /repos/${{ inputs.repository }}/actions/runners/registration-token \
+          | jq -r .token\
+        )
+
+        echo "::add-mask::$TOKEN"
+        echo "token=${TOKEN}" >> "$GITHUB_OUTPUT"

--- a/.github/actions/scaleway/cleanup/action.yml
+++ b/.github/actions/scaleway/cleanup/action.yml
@@ -1,0 +1,37 @@
+---
+name: Clean up scaleway instances
+description: Cleans up scaleway instances that might have been left behind.
+
+inputs:
+  tag:
+    description: Tag used to select the instances to clean up
+    default: 'github'
+    required: false
+
+outputs:
+  id:
+    description: ID of the created instance.
+    value: ${{ steps.create_instance.outputs.id }}
+  ip:
+    description: IP of the created instance.
+    value: ${{ steps.create_instance.outputs.ip }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check out code
+      uses: actions/checkout@v4
+
+    - name: Install scaleway-cli
+      uses: ./.github/actions/scaleway/install-cli
+
+    - name: Clean up instances with the '${{ inputs.tag }}' tag
+      shell: bash
+      run: |
+        instances="$(scw instance server list tags.0=${{ inputs.tag }} -o json | jq -r '.[].id')"
+        for id in ${instances}; do
+          echo "🕐 Terminating ${id}..."
+          scw instance server terminate "${id}" with-ip=true with-block=true
+        done
+
+        echo "Cleanup finished"

--- a/.github/actions/scaleway/create-instance/action.yml
+++ b/.github/actions/scaleway/create-instance/action.yml
@@ -1,0 +1,59 @@
+---
+name: Create scaleway instance
+description: Creates a scaleway instance
+
+inputs:
+  name:
+    description: Name of the scaleway instance.
+    required: true
+  image:
+    description: Image to use in the scaleway instance.
+    default: 'ubuntu_jammy'
+    required: false
+  type:
+    description: Type of the instance to use.
+    default: 'PRO2-XS'
+    required: false
+  root_size:
+    description: Size specification for the root block volume (e.g. 10G).
+    default: '50G'
+    required: false
+  tag:
+    description: Tag to apply to the instance
+    default: 'github'
+    required: false
+  cloud_init:
+    description: Path to a cloud-init script to pass to the command.
+    default: './.github/templates/cloud-init.cfg'
+    required: false
+
+outputs:
+  id:
+    description: ID of the created instance.
+    value: ${{ steps.create_instance.outputs.id }}
+  ip:
+    description: IP of the created instance.
+    value: ${{ steps.create_instance.outputs.ip }}
+
+runs:
+  using: composite
+  steps:
+    - name: Install scaleway-cli
+      uses: ./.github/actions/scaleway/install-cli
+
+    - name: Create instance
+      id: create_instance
+      shell: bash
+      run: |
+        instance="$(scw instance server create image="${{ inputs.image }}" \
+          type="${{ inputs.type }}" \
+          name="${{ inputs.name }}" \
+          ip=new \
+          root-volume=block:"${{ inputs.root_size }}" \
+          cloud-init=@"${{ inputs.cloud_init }}" \
+          tags.0="${{ inputs.tag }}" \
+          -o json)"
+
+        echo "id=$(jq -r .id <<< ${instance})" >> "$GITHUB_OUTPUT"
+        echo "ip=$(jq -r .public_ip.address <<< ${instance})" >> "$GITHUB_OUTPUT"
+

--- a/.github/actions/scaleway/install-cli/action.yml
+++ b/.github/actions/scaleway/install-cli/action.yml
@@ -1,0 +1,32 @@
+---
+name: Install scaleway-cli
+description: Installs scaleway-cli
+
+inputs:
+  arch:
+    description: Architecture for the binary.
+    default: 'amd64'
+    required: false
+  version:
+    description: Version tag to install.
+    default: '2.26.0'
+    required: false
+  install_path:
+    description: Full absolute path where the binary will be installed.
+    default: '/usr/local/bin/scw'
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - name: Cache Scaleway-cli
+      uses: actions/cache@v4
+      with:
+        path: ${{ inputs.install_path }}
+        key: scaleway-cli-${{ inputs.arch }}-${{ inputs.version }}
+
+    - name: Download Scaleway-cli version ${{ inputs.version }}
+      shell: bash
+      run: |
+        wget -q -O ${{ inputs.install_path }} https://github.com/scaleway/scaleway-cli/releases/download/v${{ inputs.version }}/scaleway-cli_${{ inputs.version }}_linux_${{ inputs.arch }}
+        chmod +x ${{ inputs.install_path }}

--- a/.github/templates/cloud-init.cfg
+++ b/.github/templates/cloud-init.cfg
@@ -1,0 +1,25 @@
+#cloud-config
+
+package_upgrade: true
+packages:
+  - vagrant
+  - python3
+  - python3-pip
+  - gcc
+  - build-essential
+  - make
+  - virtualbox
+  - virtualbox-qt
+  - curl
+
+runcmd:
+  - >
+    su ubuntu -c "cd /home/ubuntu
+    && mkdir actions-runner
+    && cd actions-runner
+    && touch mark_1
+    && curl -o /home/ubuntu/actions-runner.tar.gz -L https://github.com/actions/runner/releases/download/v2.312.0/actions-runner-linux-x64-2.312.0.tar.gz
+    && touch mark_2
+    && tar xzf /home/ubuntu/actions-runner.tar.gz -C /home/ubuntu/actions-runner
+    && /home/ubuntu/actions-runner/config.sh --url https://github.com/hluaces-ansible/ansible-ubuntu --unattended --token %%TOKEN%%
+    && /home/ubuntu/actions-runner/run.sh &"

--- a/.github/workflows/scaleway-cleanup.yml
+++ b/.github/workflows/scaleway-cleanup.yml
@@ -1,0 +1,28 @@
+---
+name: Clean up unused scaleway instances
+on:
+  schedule:
+    - cron: '30 */2 * * *'
+  workflow_dispatch:
+
+jobs:
+  scaleway:
+    name: Clean up self-hosted runners
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Clean up instances
+        env:
+          SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
+          SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
+          SCW_ORGANIZATION: ${{ secrets.SCW_ORGANIZATION_ID }}
+        uses: ./.github/actions/scaleway/cleanup
+
+      - name: Clean up GitHub runners
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_RUNNERS }}
+        uses: ./.github/actions/runners/delete_offline
+        with:
+          repo: ${{ github.repository }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,48 @@ run-name: Test for ${{ github.event_name }}:${{ github.ref }} (${{ github.sha }}
   schedule:
     - cron: "0 0 * * 1"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  provision-runner:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        host: ["ubuntu22-laptop", "ubuntu22-desktop"]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Install scaleway-cli
+        uses: ./.github/actions/scaleway/install-cli
+
+      - name: Create runner token
+        id: runner_token
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_RUNNERS }}
+        uses: ./.github/actions/runners/get_token
+        with:
+          repository: ${{ github.repository }}
+
+      - name: Create cloud-init file
+        shell: bash
+        run: sed -i -e "s|%%TOKEN%%|${{ steps.runner_token.outputs.token }}|g" ./.github/templates/cloud-init.cfg
+
+      - name: Provision new self-hosted runner
+        env:
+          SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
+          SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
+          SCW_ORGANIZATION: ${{ secrets.SCW_ORGANIZATION_ID }}
+        uses: ./.github/actions/scaleway/create-instance
+        with:
+          name: ${{ matrix.host }}-${{ github.sha }}
+          type: 'PRO2-S'
+
   Test:
+    needs: provision-runner
     runs-on: self-hosted
     strategy:
       fail-fast: false
@@ -80,3 +120,26 @@ jobs:
         with:
           name: vagrant-${{ matrix.host }}.log
           path: /Users/runner/.cache/molecule/ansible-ubuntu/default/vagrant.err
+
+  cleanup:
+    needs: Test
+    name: Clean up self-hosted runners
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Clean up instances
+        env:
+          SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
+          SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
+          SCW_ORGANIZATION: ${{ secrets.SCW_ORGANIZATION_ID }}
+        uses: ./.github/actions/scaleway/cleanup
+
+      - name: Clean up GitHub runners
+        env:
+          GH_TOKEN: ${{ secrets.GH_TOKEN_RUNNERS }}
+        uses: ./.github/actions/runners/delete_offline
+        with:
+          repository: ${{ github.repository }}


### PR DESCRIPTION
Rationale is to be able to provision self-hosted runners when a test run
is needed.

Due to nested virtualization, virtualbox and Vagrant, we need a very
specific setup to make these run.

Purpose is to create the self-hosted runners prior to the run, with a
few extra workflows to clean-up potential runners that were left behind
in prior runs.
