### PR TITLE
fix(ci): make scaleway/install action set default org id

### DIFF
--- a/.github/actions/scaleway/install-cli/action.yml
+++ b/.github/actions/scaleway/install-cli/action.yml
@@ -36,6 +36,10 @@ inputs:
       - pl-waw-1
       - pl-waw-2
       - pl-waw-3
+  default_organization_id:
+    description: Default organization ID to set.
+    default: ''
+    required: false
 
 runs:
   using: composite
@@ -59,3 +63,4 @@ runs:
         touch /home/runner/.config/scw/config.yaml
         ${{ inputs.install_path }} config set default-region=${{ inputs.default_region }}
         ${{ inputs.install_path }} config set default-zone=${{ inputs.default_zone }}
+        ${{ inputs.install_path }} config set default-organization-id=${{ inputs.default_organization_id }}

--- a/.github/workflows/scaleway-cleanup.yml
+++ b/.github/workflows/scaleway-cleanup.yml
@@ -17,7 +17,6 @@ jobs:
         env:
           SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
           SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
-          SCW_DEFAULT_ORGANIZATION_ID: ${{ secrets.SCW_DEFAULT_ORGANIZATION_ID }}
         uses: ./.github/actions/scaleway/cleanup
 
       - name: Clean up GitHub runners

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Install scaleway-cli
         uses: ./.github/actions/scaleway/install-cli
+        with:
+          default_organization_id: ${{ secrets.SCW_DEFAULT_ORGANIZATION_ID }}
 
       - name: Create runner token
         id: runner_token
@@ -40,7 +42,6 @@ jobs:
         env:
           SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
           SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
-          SCW_DEFAULT_ORGANIZATION_ID: ${{ secrets.SCW_DEFAULT_ORGANIZATION_ID }}
         uses: ./.github/actions/scaleway/create-instance
         with:
           name: ${{ matrix.host }}-${{ github.sha }}
@@ -134,7 +135,6 @@ jobs:
         env:
           SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
           SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_KEY }}
-          SCW_DEFAULT_ORGANIZATION_ID: ${{ secrets.SCW_DEFAULT_ORGANIZATION_ID }}
         uses: ./.github/actions/scaleway/cleanup
 
       - name: Clean up GitHub runners


### PR DESCRIPTION
This ha started to fail with:

```
Run instance="$(scw instance server create image="ubuntu_jammy" \
{"error":"scaleway-sdk-go: default organization ID cannot be empty"}
```
